### PR TITLE
Fix removed Kimi vision model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 </a>
 
 <p align="center">
-  An open source wireframe to app generator. Powered by Kimi K2.5 & Together.ai.
+  An open source wireframe to app generator. Powered by Kimi K2.7 Code & Together.ai.
 </p>
 
 ## Tech stack
 
-- [Kimi K2.5](https://togetherai.link/?utm_source=napkins&utm_medium=referral&utm_campaign=example-app) for the LLM
+- [Kimi K2.7 Code](https://togetherai.link/?utm_source=napkins&utm_medium=referral&utm_campaign=example-app) for the LLM
 - [Together AI](https://togetherai.link/?utm_source=napkins&utm_medium=referral&utm_campaign=example-app) for LLM inference
 - [Sandpack](https://sandpack.codesandbox.io/) for the code sandbox
 - [S3](https://aws.amazon.com/s3/) for image storage

--- a/app/api/generateCode/route.ts
+++ b/app/api/generateCode/route.ts
@@ -1,4 +1,5 @@
 import { getCodingPrompt } from '@/lib/prompt';
+import { NAPKINS_MODEL } from '@/lib/model';
 
 import Together from 'together-ai';
 import { z } from 'zod';
@@ -9,7 +10,6 @@ export async function POST(req: Request) {
   let json = await req.json();
   let result = z
     .object({
-      model: z.string(),
       imageUrl: z.string(),
       shadcn: z.boolean().default(false),
     })
@@ -19,15 +19,15 @@ export async function POST(req: Request) {
     return new Response(result.error.message, { status: 422 });
   }
 
-  let { model, imageUrl, shadcn } = result.data;
+  let { imageUrl, shadcn } = result.data;
   let codingPrompt = getCodingPrompt(shadcn);
 
   const res = await (together.chat.completions.create as Function)({
-    model,
-    temperature: 0.2,
+    model: NAPKINS_MODEL.id,
+    temperature: NAPKINS_MODEL.temperature,
+    top_p: NAPKINS_MODEL.topP,
     max_tokens: 65536,
     stream: true,
-    reasoning: { enabled: false },
     messages: [
       {
         role: 'user',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,8 +17,7 @@ import {
 import LoadingDots from '@/components/loading-dots';
 import { readStream } from '@/lib/utils';
 import { stripFences } from '@/lib/code-utils';
-
-const KIMI_MODEL = 'moonshotai/Kimi-K2.5';
+import { NAPKINS_MODEL } from '@/lib/model';
 
 export default function UploadComponent() {
   const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
@@ -76,7 +75,6 @@ export default function UploadComponent() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          model: KIMI_MODEL,
           shadcn,
           imageUrl,
         }),
@@ -246,7 +244,7 @@ export default function UploadComponent() {
           <span className='text-sm font-medium text-gray-600'>AI Model</span>
           <span className='flex items-center gap-2 text-sm font-semibold text-gray-900'>
             <img src='/kimi.svg' alt='' className='size-5' />
-            Kimi K2.5
+            {NAPKINS_MODEL.label}
           </span>
         </div>
         <TooltipProvider>

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -1,0 +1,6 @@
+export const NAPKINS_MODEL = {
+  id: 'moonshotai/Kimi-K2.7-Code',
+  label: 'Kimi K2.7 Code',
+  temperature: 1,
+  topP: 0.95
+} as const;

--- a/scripts/eval-fences.ts
+++ b/scripts/eval-fences.ts
@@ -5,20 +5,16 @@
  * Usage:
  *   npx tsx scripts/eval-fences.ts              # all prod models, 3 runs each
  *   npx tsx scripts/eval-fences.ts 5             # all prod models, 5 runs each
- *   npx tsx scripts/eval-fences.ts 3 "moonshotai/Kimi-K2.5"  # single model
+ *   npx tsx scripts/eval-fences.ts 3 "moonshotai/Kimi-K2.7-Code"  # single model
  */
 import Together from "together-ai";
 import * as esbuild from "esbuild";
 import * as fs from "fs";
 import { getCodingPrompt } from "../lib/prompt";
 import { stripFences } from "../lib/code-utils";
+import { NAPKINS_MODEL } from "../lib/model";
 
-const PROD_MODELS = [
-  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-  "moonshotai/Kimi-K2.5",
-  "zai-org/GLM-5",
-  "MiniMaxAI/MiniMax-M2.5",
-];
+const PROD_MODELS = [NAPKINS_MODEL.id];
 
 const IMAGE_URL =
   "https://napkinsdev.s3.us-east-1.amazonaws.com/next-s3-uploads/be191fc8-149b-43eb-b434-baf883986c2c/appointment-booking.png";
@@ -47,14 +43,16 @@ interface Result {
 
 async function runOnce(model: string, runIdx: number): Promise<Result> {
   const start = Date.now();
+  const isCurrentKimi = model === NAPKINS_MODEL.id;
 
   try {
     const res = await (together.chat.completions.create as Function)({
       model,
-      temperature: 0.2,
+      temperature: isCurrentKimi ? NAPKINS_MODEL.temperature : 0.2,
+      ...(isCurrentKimi ? { top_p: NAPKINS_MODEL.topP } : {}),
       max_tokens: 65536,
       stream: true,
-      reasoning: { enabled: false },
+      ...(isCurrentKimi ? {} : { reasoning: { enabled: false } }),
       messages: [
         {
           role: "user",


### PR DESCRIPTION
## Summary

- replace removed moonshotai/Kimi-K2.5 with moonshotai/Kimi-K2.7-Code
- keep the model configuration server-side and align the UI, README, and active eval
- use the model-recommended temperature 1.0 and top_p 0.95; K2.7 thinking cannot be disabled

Kimi K2.7 Code is available on Together serverless with image input and is specifically intended for screenshot-to-code workflows: https://www.together.ai/models/kimi-k27-code

## Production evidence

Production POST /api/generateCode requests returned 500 because moonshotai/Kimi-K2.5 was removed from serverless.

## Verification

- TOGETHER_API_KEY=build-placeholder pnpm build
- git diff --check

No synthetic production traffic was sent. This PR does not deploy or merge anything.